### PR TITLE
Add bower.json specification

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,41 @@
+{
+  name: 'fecha',
+  main: 'fecha.js',
+  version: '0.2.1',
+  homepage: 'https://github.com/taylorhakes/fecha',
+  authors: [
+    'Taylor Hakes'
+  ],
+  description: 'Date formatting and parsing',
+  moduleType: [
+    'amd',
+    'globals',
+    'node'
+  ],
+  keywords: [
+    'date',
+    'parse',
+    'moment',
+    'format',
+    'fecha',
+    'formatting'
+  ],
+  license: 'MIT',
+  ignore: [
+    '**/.*',
+    'node_modules',
+    'bower_components',
+    'test',
+    'tests'
+  ],
+  devDependencies: {
+    "karma": "^0.12.31",
+    "jasmine-core": "^2.1.3",
+    "karma-jasmine": "^0.3.4",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-coverage": "^0.2.7",
+    "gulp": "^3.8.10",
+    "gulp-uglify": "^1.0.2",
+    "gulp-rename": "^1.2.0"
+  }
+}


### PR DESCRIPTION
To be able to register fecha as a Bower package there must be a valid spec so add it.

Also, would you be willing to [register](http://bower.io/docs/creating-packages/#register) this package on [bower.io](http://bower.io)?