### PR TITLE
Add literal support for formatting masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ fecha.format(new Date(1998, 5, 3, 15, 23, 10, 350), 'YYYY-MM-DD hh:mm:ss.SSS A')
 fecha.format(new Date(2015, 10, 20), 'mediumDate'); // 'Nov 20, 2015'
 fecha.format(new Date(2015, 2, 10, 5, 30, 20), 'shortTime'); // '05:30'
 
+// Literals
+fecha.format(new Date(2001, 2, 5, 6, 7, 2, 5), '[on] MM-DD-YYYY [at] HH:mm'); // 'on 03-05-2001 at 06:07'
 ```
 
 #### Parsing

--- a/fecha.js
+++ b/fecha.js
@@ -11,6 +11,7 @@
   var threeDigits = /\d{3}/;
   var fourDigits = /\d{4}/;
   var word = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
+  var literal = /\[(.*?)\]/g;
   var noop = function () {
   };
 
@@ -237,8 +238,20 @@
 
     mask = fecha.masks[mask] || mask || fecha.masks['default'];
 
-    return mask.replace(token, function ($0) {
+    var literals = [];
+
+    //Make literals inactive by replacing them with _
+    mask = mask.replace(literal, function($0, $1) {
+      literals.push($1);
+      return '_';
+    });
+    //Apply formatting rules
+    mask = mask.replace(token, function ($0) {
       return $0 in formatFlags ? formatFlags[$0](dateObj, i18n) : $0.slice(1, $0.length - 1);
+    });
+    //Inline literal values back into the formatted value
+    return mask.replace(/_/g, function() {
+      return literals.shift();
     });
   };
 

--- a/fecha.js
+++ b/fecha.js
@@ -240,17 +240,17 @@
 
     var literals = [];
 
-    //Make literals inactive by replacing them with _
+    // Make literals inactive by replacing them with ??
     mask = mask.replace(literal, function($0, $1) {
       literals.push($1);
-      return '_';
+      return '??';
     });
-    //Apply formatting rules
+    // Apply formatting rules
     mask = mask.replace(token, function ($0) {
       return $0 in formatFlags ? formatFlags[$0](dateObj, i18n) : $0.slice(1, $0.length - 1);
     });
-    //Inline literal values back into the formatted value
-    return mask.replace(/_/g, function() {
+    // Inline literal values back into the formatted value
+    return mask.replace(/\?\?/g, function() {
       return literals.shift();
     });
   };

--- a/fecha.js
+++ b/fecha.js
@@ -11,7 +11,7 @@
   var threeDigits = /\d{3}/;
   var fourDigits = /\d{4}/;
   var word = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
-  var literal = /\[(.*?)\]/g;
+  var literal = /\[([^]*?)\]/gm;
   var noop = function () {
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fecha",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Date formatting and parsing",
   "main": "fecha.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fecha",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "Date formatting and parsing",
   "main": "fecha.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -174,6 +174,9 @@ test('no format', function() {
   assert.equal(fecha.format(new Date(2017,4,2,10)), 'Tue May 02 2017 10:00:00');
 });
 
+testFormat('literal in format', new Date(2001, 2, 5, 6, 7, 2, 5), '[on] MM-DD-YYYY [at] HH:mm',
+  'on 03-05-2001 at 06:07');
+
 test('Invalid date', function () {
   assert.throws(function () {
     fecha.format('hello', 'YYYY');

--- a/test.js
+++ b/test.js
@@ -17,6 +17,10 @@ function testFormat(name, dateObj, format, expected) {
   });
 }
 
+function suite(name, suiteBody) {
+  suiteBody();
+}
+
 testParse('basic date parse', '2012/05/03', 'YYYY/MM/DD', new Date(2012, 4, 3));
 testParse('basic date parse with time', '2012/05/03 05:01:40', 'YYYY/MM/DD HH:mm:ss', new Date(2012, 4, 3, 5, 1, 40));
 testParse('date with different slashes', '2012-05-03 05:01:40', 'YYYY-MM-DD HH:mm:ss', new Date(2012, 4, 3, 5, 1, 40));
@@ -174,8 +178,19 @@ test('no format', function() {
   assert.equal(fecha.format(new Date(2017,4,2,10)), 'Tue May 02 2017 10:00:00');
 });
 
-testFormat('literal in format', new Date(2001, 2, 5, 6, 7, 2, 5), '[on] MM-DD-YYYY [at] HH:mm',
-  'on 03-05-2001 at 06:07');
+// Literals
+suite('literals', function() {
+  var date = new Date(2009, 1, 14, 15, 25, 50, 125);
+
+  testFormat('literal in format', date, '[on] MM-DD-YYYY [at] HH:mm',
+    'on 02-14-2009 at 15:25');
+  testFormat('one literal', date, '[day]', 'day');
+  testFormat('two literals', date, '[day] YY [YY]', 'day 09 YY');
+  testFormat('incomplete literal', date, '[YY', '[09');
+  testFormat('literal inside literal', date, '[[YY]]', '[YY]');
+  testFormat('bracket inside literal', date, '[[]', '[');
+  testFormat('new lines', date, 'YYYY[\n]DD[\n]', '2009\n14\n');
+});
 
 test('Invalid date', function () {
   assert.throws(function () {


### PR DESCRIPTION
It would be nice to be able to use literals in formatting masks, for example

```javascript
fecha.format(new Date(2001, 2, 5, 6, 7, 2, 5), '[on] MM-DD-YYYY [at] HH:mm'); 
// 'on 03-05-2001 at 06:07'
```

moment.js includes support for literals as well http://stackoverflow.com/questions/28241002/moment-js-include-text-in-middle-of-date-format

This PR adds support for literals in formatting masks, updates README to include an example of literal usage and increases the minor version number.