### PR TITLE
Adds fecha.info() and fecha.valid() methods and tests

### DIFF
--- a/fecha.js
+++ b/fecha.js
@@ -360,6 +360,44 @@
     return date;
   };
 
+  /**
+   * Evaluates if a date is valid or not
+   * @method valid
+   * @param {string} dateStr Date string
+   * @param {string} format Date parse format
+   * @returns {boolean}
+   */
+  fecha.valid = function(dateStr, format, i18nSettings) {
+    try {
+      var info1 = fecha.info(dateStr, format, i18nSettings);
+      if (!info1) {
+        return false;
+      }
+
+      var info2 = fecha.info(fecha.format(fecha.parse(dateStr, format, i18nSettings), format, i18nSettings), format, i18nSettings);
+      if (!info2) {
+        return false;
+      }
+
+      var valid = true;
+      Object.keys(info1).forEach(function (key) {
+        if (info1[key] !== info2[key]) {
+          valid = false;
+        }
+      });
+      if (valid) {
+        Object.keys(info2).forEach(function (key) {
+          if (info1[key] !== info2[key]) {
+            valid = false;
+          }
+        });
+      }
+      return valid;
+    } catch (e) {
+      return false;
+    }
+  };
+
   /* istanbul ignore next */
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = fecha;

--- a/fecha.js
+++ b/fecha.js
@@ -255,18 +255,18 @@
     });
   };
 
-  /**
-   * Parse a date string into an object, changes - into /
-   * @method parse
+  /** 
+   * Retrieves info about a date string
+   * @method info
    * @param {string} dateStr Date string
    * @param {string} format Date parse format
-   * @returns {Date|boolean}
+   * @returns {Object}
    */
-  fecha.parse = function (dateStr, format, i18nSettings) {
+  fecha.info = function (dateStr, format, i18nSettings) {
     var i18n = i18nSettings || fecha.i18n;
 
     if (typeof format !== 'string') {
-      throw new Error('Invalid format in fecha.parse');
+      throw new Error('Invalid format in fecha.info');
     }
 
     format = fecha.masks[format] || format;
@@ -297,20 +297,60 @@
       return parseFlags[$0] ? '' : $0.slice(1, $0.length - 1);
     });
 
-    if (!isValid) {
-      return false;
-    }
-
-    var today = new Date();
     if (dateInfo.isPm === true && dateInfo.hour != null && +dateInfo.hour !== 12) {
       dateInfo.hour = +dateInfo.hour + 12;
     } else if (dateInfo.isPm === false && +dateInfo.hour === 12) {
       dateInfo.hour = 0;
     }
 
-    var date;
     if (dateInfo.timezoneOffset != null) {
       dateInfo.minute = +(dateInfo.minute || 0) - +dateInfo.timezoneOffset;
+    }
+
+    ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond'].forEach(function (prop) {
+      if (dateInfo.hasOwnProperty(prop)) {
+        dateInfo[prop] = parseInt(dateInfo[prop], 10);
+      }
+    });
+
+    if (!isValid) {
+      return null;
+    }
+
+    return dateInfo;
+  };
+
+  /**
+   * Parse a date string into an object, changes - into /
+   * @method parse
+   * @param {string} dateStr Date string
+   * @param {string} format Date parse format
+   * @returns {Date|boolean}
+   */
+  fecha.parse = function (dateStr, format, i18nSettings) {
+    var i18n = i18nSettings || fecha.i18n;
+
+    if (typeof format !== 'string') {
+      throw new Error('Invalid format in fecha.parse');
+    }
+
+    format = fecha.masks[format] || format;
+
+    // Avoid regular expression denial of service, fail early for really long strings
+    // https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS
+    if (dateStr.length > 1000) {
+      return false;
+    }
+
+    var dateInfo = fecha.info(dateStr, format, i18n);
+
+    if (!dateInfo) {
+      return false;
+    }
+
+    var today = new Date();
+    var date;
+    if (dateInfo.timezoneOffset != null) {
       date = new Date(Date.UTC(dateInfo.year || today.getFullYear(), dateInfo.month || 0, dateInfo.day || 1,
         dateInfo.hour || 0, dateInfo.minute || 0, dateInfo.second || 0, dateInfo.millisecond || 0));
     } else {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,12 @@ var assert = painless.assert;
 var today = new Date();
 var year = today.getFullYear();
 
+function testValid(name, str, format, expected) {
+  test(name, function() {
+    assert.equal(fecha.valid(str, format), expected);
+  });
+}
+
 function testInfo(name, str, format, expected) {
   test(name, function() {
     assert.deepEqual(fecha.info(str, format), expected);
@@ -26,6 +32,12 @@ function testFormat(name, dateObj, format, expected) {
 function suite(name, suiteBody) {
   suiteBody();
 }
+
+testValid('identifies valid dates', '1985-12-8', 'YYYY-MM-DD', true);
+testValid('identifies invalid month', '2015-13-29', 'YYYY-MM-DD', false);
+testValid('identifies invalid day', '2015-1-0', 'YYYY-MM-DD', false);
+testValid('identifies invalid day relative to month', '2015-2-29', 'YYYY-MM-DD', false);
+testValid('identifies bogus dates', 'hello', 'YYYY-MM-DD', false);
 
 testInfo('basic date info', '2012/05/03', 'YYYY/MM/DD', {year:2012, month: 4, day: 3});
 testInfo('basic date info with time', '2012/05/03 05:01:40', 'YYYY/MM/DD HH:mm:ss', {year:2012, month: 4, day: 3, hour: 5, minute: 1, second: 40});

--- a/test.js
+++ b/test.js
@@ -5,6 +5,12 @@ var assert = painless.assert;
 var today = new Date();
 var year = today.getFullYear();
 
+function testInfo(name, str, format, expected) {
+  test(name, function() {
+    assert.deepEqual(fecha.info(str, format), expected);
+  });
+}
+
 function testParse(name, str, format, date) {
   test(name, function() {
     assert.equal(+fecha.parse(str, format), +date);
@@ -20,6 +26,13 @@ function testFormat(name, dateObj, format, expected) {
 function suite(name, suiteBody) {
   suiteBody();
 }
+
+testInfo('basic date info', '2012/05/03', 'YYYY/MM/DD', {year:2012, month: 4, day: 3});
+testInfo('basic date info with time', '2012/05/03 05:01:40', 'YYYY/MM/DD HH:mm:ss', {year:2012, month: 4, day: 3, hour: 5, minute: 1, second: 40});
+testInfo('handles am', '2000-01-01 11am', 'YYYY-MM-DD hha', {year: 2000, month: 0, day: 1, hour: 11, isPm: false});
+testInfo('handles pm', '2000-01-01 12pm', 'YYYY-MM-DD hha', {year: 2000, month: 0, day: 1, hour: 12, isPm: true});
+testInfo('only returns what is provided', '3rd May', 'Do MMM', {month: 4, day: 3});
+testInfo('handles milliseconds', '10:20:30.123', 'HH:mm:ss.SSS', {hour: 10, minute: 20, second: 30, millisecond: 123});
 
 testParse('basic date parse', '2012/05/03', 'YYYY/MM/DD', new Date(2012, 4, 3));
 testParse('basic date parse with time', '2012/05/03 05:01:40', 'YYYY/MM/DD HH:mm:ss', new Date(2012, 4, 3, 5, 1, 40));


### PR DESCRIPTION
Finding myself needing to inspect the properties of a parsed date string quite often.

```javascript
fecha.info('1985-12-08', 'YYYY-MM-DD')
// {year: 1985, month: 11, day: 8}
```

Also useful to know if a date is valid or not.

```javascript
fecha.valid('2015-2-29', 'YYYY-MM-DD')
// false
```