### PR TITLE
Reduce size of NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "nyc": "^5.6.0",
     "painless": "^0.9.1",
     "uglify-js": "^2.6.1"
-  }
+  },
+  "files": [
+    "fecha.js",
+    "fecha.min.js"
+  ]
 }


### PR DESCRIPTION
The NPM package contains a lot of files that are not needed to use fecha. This change reduces the package to just the source and minified files. The README and LICENSE files are always included, by the way.

The files that are currently in the package are:

- bower.json
- CHANGELOG.md
- CONTRIBUTING.md
- .editorconfig
- .eslintrc.js
- fecha.js
- fecha.min.js
- .idea
- LICENSE
- .npmignore
- package.json
- README.md
- test.js
- .travis.yml

My preference is to not include tests, but if you want to keep them in the NPM package I'll update the PR.