### PR TITLE
Quoted object key 'default'

### DIFF
--- a/fecha.js
+++ b/fecha.js
@@ -209,7 +209,7 @@
 
   // Some common format strings
   fecha.masks = {
-    default: 'ddd MMM DD YYYY HH:mm:ss',
+    'default': 'ddd MMM DD YYYY HH:mm:ss',
     shortDate: 'M/D/YY',
     mediumDate: 'MMM D, YYYY',
     longDate: 'MMMM D, YYYY',


### PR DESCRIPTION
My (not very smart) minifier chokes on 'default' as a JS reserved word.