### PR TITLE
Add typescript typings to npm output

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "files": [
     "fecha.js",
-    "fecha.min.js"
+    "fecha.min.js",
+    "fecha.d.ts"
   ],
   "types": "./fecha.d.ts"
 }


### PR DESCRIPTION
When the files array is specified, only the files listed there are included, as per: https://docs.npmjs.com/files/package.json#files

This PR changes that, so the typescript typings are also included.

Fixes #39 