### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "fecha.min.js",
     "fecha.d.ts"
   ],
-  "types": "./fecha.d.ts"
+  "types": "./src/fecha.d.ts"
 }

--- a/src/fecha.d.ts
+++ b/src/fecha.d.ts
@@ -36,12 +36,13 @@ export interface Masks {
     [myMask: string]: string;
 }
 
-export let masks: Masks;
+interface Fecha {
+    masks: Masks;
+    i18n: i18nSettings;
+    format(dateObj: Date | number, mask: string, i18nSettings?: i18nSettings): string;
+    parse(dateStr: string, format: string, i18nSettings?: i18nSettings): Date | boolean;
+}
 
-export let i18n: i18nSettings;
+declare const fechaObj: Fecha;
 
-export function format(dateObj: Date | number, mask: string, i18nSettings?: i18nSettings): string;
-
-export function parse(dateStr: string, format: string, i18nSettings?: i18nSettings): Date | boolean;
-
-export as namespace Fecha;
+export default fechaObj;


### PR DESCRIPTION
The types file was exporting the types as a namespace. This caused TypeScript to think the correct way is to do `import { format } from "fecha";`, however, Fecha only exports a default object with that method.

This fixes it.